### PR TITLE
Bumping supported versions of HF

### DIFF
--- a/examples/nlg-reddit/author-level-dp/environment.yml
+++ b/examples/nlg-reddit/author-level-dp/environment.yml
@@ -95,7 +95,7 @@ dependencies:
     - secretstorage==3.3.1
     - tokenizers==0.10.3
     - tqdm==4.62.3
-    - transformers>=4.20.1
+    - transformers==4.20.1
     - typing_extensions==4.0.1
     - urllib3==1.26.7
     - xxhash==2.0.2

--- a/examples/nlg-reddit/author-level-dp/environment.yml
+++ b/examples/nlg-reddit/author-level-dp/environment.yml
@@ -95,7 +95,7 @@ dependencies:
     - secretstorage==3.3.1
     - tokenizers==0.10.3
     - tqdm==4.62.3
-    - transformers==4.10.3
+    - transformers>=4.20.1
     - typing_extensions==4.0.1
     - urllib3==1.26.7
     - xxhash==2.0.2

--- a/examples/nlg-reddit/sample-level-dp/environment.yml
+++ b/examples/nlg-reddit/sample-level-dp/environment.yml
@@ -95,7 +95,7 @@ dependencies:
     - secretstorage==3.3.1
     - tokenizers==0.10.3
     - tqdm==4.62.3
-    - transformers>=4.20.1
+    - transformers==4.20.1
     - typing_extensions==4.0.1
     - urllib3==1.26.7
     - xxhash==2.0.2

--- a/examples/nlg-reddit/sample-level-dp/environment.yml
+++ b/examples/nlg-reddit/sample-level-dp/environment.yml
@@ -95,7 +95,7 @@ dependencies:
     - secretstorage==3.3.1
     - tokenizers==0.10.3
     - tqdm==4.62.3
-    - transformers==4.10.3
+    - transformers>=4.20.1
     - typing_extensions==4.0.1
     - urllib3==1.26.7
     - xxhash==2.0.2

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         ]
     },
     install_requires=[
-        "transformers>=4.10.0",
+        "transformers>=4.20.1",
         "datasets<2.0.0",
         "opacus<1.0.0",
         "prv-accountant",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     },
     install_requires=[
         "transformers>=4.20.1",
-        "datasets<2.0.0",
+        "datasets>=2.0.0",
         "opacus<1.0.0",
         "prv-accountant<0.2.0",
         "torch<1.10"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "transformers>=4.20.1",
         "datasets<2.0.0",
         "opacus<1.0.0",
-        "prv-accountant",
+        "prv-accountant<0.2.0",
         "torch<1.10"
     ],
     test_suite="tests",

--- a/src/dp_transformers/arguments.py
+++ b/src/dp_transformers/arguments.py
@@ -4,7 +4,7 @@
 from transformers import TrainingArguments as HfTrainingArguments
 from transformers import IntervalStrategy, logging
 from dataclasses import dataclass, field
-from datasets import tqdm_utils
+from datasets.utils import disable_progress_bar
 
 from typing import Optional
 
@@ -55,4 +55,4 @@ class TrainingArguments(HfTrainingArguments):
             self.max_steps = 2
 
         if self.disable_tqdm:
-            tqdm_utils.disable_progress_bar()
+            disable_progress_bar()

--- a/src/dp_transformers/dp_utils.py
+++ b/src/dp_transformers/dp_utils.py
@@ -206,10 +206,11 @@ class OpacusDPTrainer(Trainer):
         if is_sagemaker_mp_enabled():
             raise NotImplementedError("DP currently doesn't support this")
 
-        if self.use_amp:
+        if self.use_cuda_amp or self.use_cpu_amp:
             raise NotImplementedError("DP currently doesn't support this.")
         else:
-            loss = self.compute_loss(model, inputs)
+            with self.compute_loss_context_manager():
+                loss = self.compute_loss(model, inputs)
 
         if self.args.n_gpu > 1:
             loss = loss.mean()  # mean() to average on multi-gpu parallel training
@@ -219,7 +220,7 @@ class OpacusDPTrainer(Trainer):
         # that is returned in order for the logging to work correctly. Hence we scale the loss after the call to 
         # loss.backward()
 
-        if self.use_amp:
+        if self.use_cuda_amp or self.use_cpu_amp:
             raise NotImplementedError("DP currently doesn't support this")
         elif self.use_apex:
             raise NotImplementedError("DP currently doesn't support this")


### PR DESCRIPTION
Now supporting HF versions >=4.20.1
Minor changes needed: 
1. `use_amp` -> `use_cuda_amp` and `use_cpu_amp`
2. Additional `compute_loss_context_manager` in training script