### PR TITLE
use opt_einsum with the new version of Opacus

### DIFF
--- a/src/dp_transformers/grad_sample/lora/lora_layer.py
+++ b/src/dp_transformers/grad_sample/lora/lora_layer.py
@@ -5,6 +5,8 @@ from typing import Dict
 
 import torch
 import torch.nn as nn
+from opt_einsum import contract
+
 from opacus.grad_sample.utils import register_grad_sampler
 
 from dp_transformers.layers.dp_merged_linear import Conv1DZeroInit
@@ -20,15 +22,15 @@ def compute_lora_conv_1d_zero_init_grad_sample(
     out_features = layer.out_features
     
     if layer.groups == 1:
-        ret[layer.weight] = torch.einsum("nki,njk->nij", B, A).unsqueeze(-1)
+        ret[layer.weight] = contract("nki,njk->nij", B, A).unsqueeze(-1)
     elif layer.groups == 2:
-        gs1 = torch.einsum("nki,njk->nij", B[:, :, :out_features//2], A[:, :in_features, :])
-        gs2 = torch.einsum("nki,njk->nij", B[:, :, out_features//2:], A[:, in_features:, :])
+        gs1 = contract("nki,njk->nij", B[:, :, :out_features//2], A[:, :in_features, :])
+        gs2 = contract("nki,njk->nij", B[:, :, out_features//2:], A[:, in_features:, :])
         ret[layer.weight] = torch.cat((gs1, gs2), 1).unsqueeze(-1)
     elif layer.groups == 3:
-        gs1 = torch.einsum("nki,njk->nij", B[:, :, :out_features//3], A[:, :in_features, :])
-        gs2 = torch.einsum("nki,njk->nij", B[:, :, out_features//3:2*out_features//3], A[:, in_features:2*in_features, :])
-        gs3 = torch.einsum("nki,njk->nij", B[:, :, 2*out_features//3:], A[:, 2*in_features:3*in_features, :])
+        gs1 = contract("nki,njk->nij", B[:, :, :out_features//3], A[:, :in_features, :])
+        gs2 = contract("nki,njk->nij", B[:, :, out_features//3:2*out_features//3], A[:, in_features:2*in_features, :])
+        gs3 = contract("nki,njk->nij", B[:, :, 2*out_features//3:], A[:, 2*in_features:3*in_features, :])
         ret[layer.weight] = torch.cat((gs1, gs2, gs3), 1).unsqueeze(-1)
     else:
         raise Exception("groups can only be 1, 2, or 3 in LoRA")

--- a/src/dp_transformers/grad_sample/transformers/conv_1d.py
+++ b/src/dp_transformers/grad_sample/transformers/conv_1d.py
@@ -5,6 +5,8 @@ from typing import Dict
 
 import torch
 import torch.nn as nn
+from opt_einsum import contract
+
 from opacus.grad_sample.utils import register_grad_sampler
 
 from transformers.modeling_utils import Conv1D
@@ -14,7 +16,7 @@ def compute_transformers_conv1d_grad_sample(
     layer: Conv1D, A: torch.Tensor, B: torch.Tensor
 ) -> Dict[nn.Parameter, torch.Tensor]:
     ret = {}
-    ret[layer.weight] = torch.einsum("n...i,n...j->nji", B, A).contiguous()
+    ret[layer.weight] = contract("n...i,n...j->nji", B, A).contiguous()
     if layer.bias is not None:
-        ret[layer.bias] = torch.einsum("n...k->nk", B)
+        ret[layer.bias] = contract("n...k->nk", B)
     return ret


### PR DESCRIPTION
Just as replaced in the new version of Opacus, here we switch to using einsum from https://optimized-einsum.readthedocs.io/en/stable/ that can significantly reduce the overall execution time of einsum-like expressions by optimizing the expression’s contraction order and dispatching many operations to canonical BLAS, cuBLAS, or other specialized routines (quoted from the website).