### PR TITLE
remove `DPCallback.on_step_begin` to prevent DP-SGD step on the first gradient accumulation step

### DIFF
--- a/src/dp_transformers/dp_utils.py
+++ b/src/dp_transformers/dp_utils.py
@@ -57,9 +57,6 @@ class DPCallback(TrainerCallback):
 
         self.on_substep_end_was_called = True
 
-    def on_step_begin(self, args: training_args.TrainingArguments, state: TrainerState, control: TrainerControl, optimizer=None, **kwargs): 
-        optimizer.signal_skip_step(do_skip=False)
-
     def on_step_end(self, args: training_args.TrainingArguments, state: TrainerState, control: TrainerControl, optimizer=None, **kwargs):
         if not (
             args.gradient_accumulation_steps <= 1 or


### PR DESCRIPTION
HF calls on_step_begin using step (https://github.com/huggingface/transformers/blob/ae54e3c3b18bac0832ad62ea9b896dfd52a09850/src/transformers/trainer.py#L1779) instead of step + 1 just like the very next line. 

Because of that, first gradient accumulation step our dp_utils calls `optimizer.signal_skip_step(do_skip=False)` and that initiates the list `optimizer.step_skip_queue` as `[False]`. Because of that although in the first gradient accumulation step we call `optimizer.signal_skip_step(do_skip=True)`, that makes the list `[False, True]` and during optimization it pops the first item, which is False. So basically the first gradient accumulation step, because of this, it does end up calling optimizer.step() and makes an update.

The solution is to remove `on_step_begin` in our dp_utils, so that it won't run `optimizer.signal_skip_step(do_skip=False)`. This operation is not needed anyways, it's sufficient to just call `optimizer.signal_skip_step(do_skip=True)` during gradient accumulation solely.